### PR TITLE
Fix the favicon not properly showing on Google Chrome browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,9 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="style.css">
   <link rel="icon" href="public/favicon/favicon.ico">
+  <link rel="icon" type="image/png" sizes="32x32" href="public/favicon/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="public/favicon/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="public/favicon/apple-touch-icon.png">
   <meta name="description" content="Doni Wicaksono's front page">
   <meta name="author" content="Doni Wicaksono">
   <meta name="keywords" content="Doni Wicaksono, Software Engineering, Personal Website">

--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -16,6 +16,21 @@
       "src": "public/favicon/favicon.ico",
       "sizes": "48x48",
       "type": "image/x-icon"
+    },
+    {
+      "src": "public/favicon/favicon-32x32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "public/favicon/favicon-16x16.png",
+      "sizes": "16x16",
+      "type": "image/png"
+    },
+    {
+      "src": "public/favicon/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png"
     }
   ],
   "theme_color": "#ffffff",


### PR DESCRIPTION
Add favicon links and entries to support proper display on Google Chrome browser.

* **index.html**
  - Add link to 32x32 PNG favicon in the `<head>` section.
  - Add link to 16x16 PNG favicon in the `<head>` section.
  - Add link to 180x180 PNG apple touch icon in the `<head>` section.

* **public/favicon/site.webmanifest**
  - Add icon entry for 32x32 PNG favicon.
  - Add icon entry for 16x16 PNG favicon.
  - Add icon entry for 180x180 PNG apple touch icon.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/slashedzer0/slashedzer0.github.io/pull/7?shareId=15dae496-fb15-4794-b4e5-878515ab7fc3).